### PR TITLE
Implementation of TICKET-102.

### DIFF
--- a/src/main/java/ee/taltech/inbankbackend/config/DecisionEngineConstants.java
+++ b/src/main/java/ee/taltech/inbankbackend/config/DecisionEngineConstants.java
@@ -1,14 +1,19 @@
 package ee.taltech.inbankbackend.config;
 
+import java.time.LocalDate;
+
 /**
  * Holds all necessary constants for the decision engine.
  */
 public class DecisionEngineConstants {
-    public static final Integer MINIMUM_LOAN_AMOUNT = 2000;
-    public static final Integer MAXIMUM_LOAN_AMOUNT = 10000;
-    public static final Integer MAXIMUM_LOAN_PERIOD = 60;
-    public static final Integer MINIMUM_LOAN_PERIOD = 12;
-    public static final Integer SEGMENT_1_CREDIT_MODIFIER = 100;
-    public static final Integer SEGMENT_2_CREDIT_MODIFIER = 300;
-    public static final Integer SEGMENT_3_CREDIT_MODIFIER = 1000;
+	public static final Integer MINIMUM_LOAN_AMOUNT = 2000;
+	public static final Integer MAXIMUM_LOAN_AMOUNT = 10000;
+	public static final Integer MAXIMUM_LOAN_PERIOD = 60;
+	public static final Integer MINIMUM_LOAN_PERIOD = 12;
+	public static final Integer SEGMENT_1_CREDIT_MODIFIER = 100;
+	public static final Integer SEGMENT_2_CREDIT_MODIFIER = 300;
+	public static final Integer SEGMENT_3_CREDIT_MODIFIER = 1000;
+	public static final LocalDate MINIMUM_AGE = LocalDate.now().minusYears(18);
+	public static final LocalDate MAXIMUM_AGE = LocalDate.now().minusYears(75);
+	public static final String[] BALTIC_COUNTRIES = { "Estonia", "Latvia", "Lithuania" };
 }

--- a/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionEngineController.java
+++ b/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionEngineController.java
@@ -1,11 +1,5 @@
 package ee.taltech.inbankbackend.endpoint;
 
-import ee.taltech.inbankbackend.exceptions.InvalidLoanAmountException;
-import ee.taltech.inbankbackend.exceptions.InvalidLoanPeriodException;
-import ee.taltech.inbankbackend.exceptions.InvalidPersonalCodeException;
-import ee.taltech.inbankbackend.exceptions.NoValidLoanException;
-import ee.taltech.inbankbackend.service.Decision;
-import ee.taltech.inbankbackend.service.DecisionEngine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,61 +9,79 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import ee.taltech.inbankbackend.exceptions.InvalidCountryException;
+import ee.taltech.inbankbackend.exceptions.InvalidCustomerAgeException;
+import ee.taltech.inbankbackend.exceptions.InvalidLoanAmountException;
+import ee.taltech.inbankbackend.exceptions.InvalidLoanPeriodException;
+import ee.taltech.inbankbackend.exceptions.InvalidPersonalCodeException;
+import ee.taltech.inbankbackend.exceptions.NoValidLoanException;
+import ee.taltech.inbankbackend.service.Decision;
+import ee.taltech.inbankbackend.service.DecisionEngine;
+
 @RestController
 @RequestMapping("/loan")
 @CrossOrigin
 public class DecisionEngineController {
 
-    private final DecisionEngine decisionEngine;
-    private final DecisionResponse response;
+	private final DecisionEngine decisionEngine;
+	private final DecisionResponse response;
 
-    @Autowired
-    DecisionEngineController(DecisionEngine decisionEngine, DecisionResponse response) {
-        this.decisionEngine = decisionEngine;
-        this.response = response;
-    }
+	@Autowired
+	DecisionEngineController(DecisionEngine decisionEngine, DecisionResponse response) {
+		this.decisionEngine = decisionEngine;
+		this.response = response;
+	}
 
-    /**
-     * A REST endpoint that handles requests for loan decisions.
-     * The endpoint accepts POST requests with a request body containing the customer's personal ID code,
-     * requested loan amount, and loan period.<br><br>
-     * - If the loan amount or period is invalid, the endpoint returns a bad request response with an error message.<br>
-     * - If the personal ID code is invalid, the endpoint returns a bad request response with an error message.<br>
-     * - If an unexpected error occurs, the endpoint returns an internal server error response with an error message.<br>
-     * - If no valid loans can be found, the endpoint returns a not found response with an error message.<br>
-     * - If a valid loan is found, a DecisionResponse is returned containing the approved loan amount and period.
-     *
-     * @param request The request body containing the customer's personal ID code, requested loan amount, and loan period
-     * @return A ResponseEntity with a DecisionResponse body containing the approved loan amount and period, and an error message (if any)
-     */
-    @PostMapping("/decision")
-    public ResponseEntity<DecisionResponse> requestDecision(@RequestBody DecisionRequest request) {
-        try {
-            Decision decision = decisionEngine.
-                    calculateApprovedLoan(request.getPersonalCode(), request.getLoanAmount(), request.getLoanPeriod());
-            response.setLoanAmount(decision.getLoanAmount());
-            response.setLoanPeriod(decision.getLoanPeriod());
-            response.setErrorMessage(decision.getErrorMessage());
+	/**
+	 * A REST endpoint that handles requests for loan decisions. The endpoint
+	 * accepts POST requests with a request body containing the customer's personal
+	 * ID code, requested loan amount, and loan period.<br>
+	 * <br>
+	 * - If the loan amount or period is invalid, the endpoint returns a bad request
+	 * response with an error message.<br>
+	 * - If the personal ID code is invalid, the endpoint returns a bad request
+	 * response with an error message.<br>
+	 * - If an unexpected error occurs, the endpoint returns an internal server
+	 * error response with an error message.<br>
+	 * - If no valid loans can be found, the endpoint returns a not found response
+	 * with an error message.<br>
+	 * - If a valid loan is found, a DecisionResponse is returned containing the
+	 * approved loan amount and period.
+	 *
+	 * @param request The request body containing the customer's personal ID code,
+	 *                requested loan amount, and loan period
+	 * @return A ResponseEntity with a DecisionResponse body containing the approved
+	 *         loan amount and period, and an error message (if any)
+	 */
+	@PostMapping("/decision")
+	public ResponseEntity<DecisionResponse> requestDecision(@RequestBody DecisionRequest request) {
+		try {
+			Decision decision = decisionEngine.calculateApprovedLoan(request.getPersonalCode(), request.getLoanAmount(),
+					request.getLoanPeriod(), request.getCountry());
+			response.setLoanAmount(decision.getLoanAmount());
+			response.setLoanPeriod(decision.getLoanPeriod());
+			response.setErrorMessage(decision.getErrorMessage());
 
-            return ResponseEntity.ok(response);
-        } catch (InvalidPersonalCodeException | InvalidLoanAmountException | InvalidLoanPeriodException e) {
-            response.setLoanAmount(null);
-            response.setLoanPeriod(null);
-            response.setErrorMessage(e.getMessage());
+			return ResponseEntity.ok(response);
+		} catch (InvalidPersonalCodeException | InvalidLoanAmountException | InvalidLoanPeriodException
+				| InvalidCountryException | InvalidCustomerAgeException e) {
+			response.setLoanAmount(null);
+			response.setLoanPeriod(null);
+			response.setErrorMessage(e.getMessage());
 
-            return ResponseEntity.badRequest().body(response);
-        } catch (NoValidLoanException e) {
-            response.setLoanAmount(null);
-            response.setLoanPeriod(null);
-            response.setErrorMessage(e.getMessage());
+			return ResponseEntity.badRequest().body(response);
+		} catch (NoValidLoanException e) {
+			response.setLoanAmount(null);
+			response.setLoanPeriod(null);
+			response.setErrorMessage(e.getMessage());
 
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-        } catch (Exception e) {
-            response.setLoanAmount(null);
-            response.setLoanPeriod(null);
-            response.setErrorMessage("An unexpected error occurred");
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+		} catch (Exception e) {
+			response.setLoanAmount(null);
+			response.setLoanPeriod(null);
+			response.setErrorMessage("An unexpected error occurred");
 
-            return ResponseEntity.internalServerError().body(response);
-        }
-    }
+			return ResponseEntity.internalServerError().body(response);
+		}
+	}
 }

--- a/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionRequest.java
+++ b/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionRequest.java
@@ -14,4 +14,5 @@ public class DecisionRequest {
 	private String personalCode;
 	private Long loanAmount;
 	private int loanPeriod;
+	private String country;
 }

--- a/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionResponse.java
+++ b/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionResponse.java
@@ -1,8 +1,9 @@
 package ee.taltech.inbankbackend.endpoint;
 
+import org.springframework.stereotype.Component;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.stereotype.Component;
 
 /**
  * Holds the response data of the REST endpoint.
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Setter
 @Component
 public class DecisionResponse {
-    private Integer loanAmount;
-    private Integer loanPeriod;
-    private String errorMessage;
+	private Integer loanAmount;
+	private Integer loanPeriod;
+	private String errorMessage;
 }

--- a/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidCountryException.java
+++ b/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidCountryException.java
@@ -1,0 +1,28 @@
+package ee.taltech.inbankbackend.exceptions;
+
+/**
+ * Thrown when requested country is invalid.
+ */
+public class InvalidCountryException extends Throwable {
+	private final String message;
+	private final Throwable cause;
+
+	public InvalidCountryException(String message) {
+		this(message, null);
+	}
+
+	public InvalidCountryException(String message, Throwable cause) {
+		this.message = message;
+		this.cause = cause;
+	}
+
+	@Override
+	public Throwable getCause() {
+		return cause;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidCustomerAgeException.java
+++ b/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidCustomerAgeException.java
@@ -1,0 +1,25 @@
+package ee.taltech.inbankbackend.exceptions;
+
+public class InvalidCustomerAgeException extends Throwable {
+	private final String message;
+	private final Throwable cause;
+
+	public InvalidCustomerAgeException(String message) {
+		this(message, null);
+	}
+
+	public InvalidCustomerAgeException(String message, Throwable cause) {
+		this.message = message;
+		this.cause = cause;
+	}
+
+	@Override
+	public Throwable getCause() {
+		return cause;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/ee/taltech/inbankbackend/service/AgeVerificator.java
+++ b/src/main/java/ee/taltech/inbankbackend/service/AgeVerificator.java
@@ -1,0 +1,33 @@
+package ee.taltech.inbankbackend.service;
+
+import java.time.LocalDate;
+
+import com.github.vladislavgoltjajev.personalcode.exception.PersonalCodeException;
+import com.github.vladislavgoltjajev.personalcode.locale.estonia.EstonianPersonalCodeParser;
+
+import ee.taltech.inbankbackend.config.DecisionEngineConstants;
+
+public class AgeVerificator {
+
+	public static LocalDate extractDateOfBirth(String personalCode) {
+		// Assuming that personal code is in the same format in all countries
+
+		EstonianPersonalCodeParser parser = new EstonianPersonalCodeParser();
+		LocalDate dateOfBirth = null;
+		try {
+			dateOfBirth = parser.getDateOfBirth(personalCode);
+		} catch (PersonalCodeException e) {
+			e.printStackTrace();
+		}
+		return dateOfBirth;
+	}
+
+	public static boolean isValidAge(String personalCode, int loanPeriod) {
+		LocalDate dateOfBirth = extractDateOfBirth(personalCode);
+		LocalDate maxAgeMinusLoanPeriod = DecisionEngineConstants.MAXIMUM_AGE.minusMonths(loanPeriod);
+
+		return dateOfBirth.getYear() < DecisionEngineConstants.MINIMUM_AGE.getYear()
+				&& dateOfBirth.getYear() > maxAgeMinusLoanPeriod.getYear();
+	}
+
+}

--- a/src/main/java/ee/taltech/inbankbackend/service/Decision.java
+++ b/src/main/java/ee/taltech/inbankbackend/service/Decision.java
@@ -12,4 +12,12 @@ public class Decision {
 	private final Integer loanAmount;
 	private final Integer loanPeriod;
 	private final String errorMessage;
+	private String county;
+
+	public Decision(Integer loanAmount, Integer loanPeriod, String errorMessage) {
+		this.loanAmount = loanAmount;
+		this.loanPeriod = loanPeriod;
+		this.errorMessage = errorMessage;
+	}
+
 }

--- a/src/test/java/ee/taltech/inbankbackend/service/DecisionEngineTest.java
+++ b/src/test/java/ee/taltech/inbankbackend/service/DecisionEngineTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import ee.taltech.inbankbackend.config.DecisionEngineConstants;
+import ee.taltech.inbankbackend.exceptions.InvalidCountryException;
+import ee.taltech.inbankbackend.exceptions.InvalidCustomerAgeException;
 import ee.taltech.inbankbackend.exceptions.InvalidLoanAmountException;
 import ee.taltech.inbankbackend.exceptions.InvalidLoanPeriodException;
 import ee.taltech.inbankbackend.exceptions.InvalidPersonalCodeException;
@@ -20,6 +22,8 @@ class DecisionEngineTest {
 	private String segment1PersonalCode;
 	private String segment2PersonalCode;
 	private String segment3PersonalCode;
+	private String ageUnderLifetime;
+	private String ageOverLifetime;
 
 	@BeforeEach
 	void setUp() {
@@ -27,6 +31,8 @@ class DecisionEngineTest {
 		segment1PersonalCode = "50307172740";
 		segment2PersonalCode = "38411266610";
 		segment3PersonalCode = "35006069515";
+		ageUnderLifetime = "60605206610";
+		ageOverLifetime = "44110230825";
 
 		// Didn't figure out how to inject components with Mockito,
 		// didn't work with it yet.
@@ -36,29 +42,32 @@ class DecisionEngineTest {
 	@Test
 	void testDebtorPersonalCode() {
 		assertThrows(NoValidLoanException.class,
-				() -> decisionEngine.calculateApprovedLoan(debtorPersonalCode, 4000L, 12));
+				() -> decisionEngine.calculateApprovedLoan(debtorPersonalCode, 4000L, 12, "Estonia"));
 	}
 
 	@Test
-	void testSegment1PersonalCode() throws InvalidLoanPeriodException, NoValidLoanException,
-			InvalidPersonalCodeException, InvalidLoanAmountException {
-		Decision decision = decisionEngine.calculateApprovedLoan(segment1PersonalCode, 4000L, 12);
+	void testSegment1PersonalCode()
+			throws InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
+			InvalidLoanAmountException, InvalidCountryException, InvalidCustomerAgeException {
+		Decision decision = decisionEngine.calculateApprovedLoan(segment1PersonalCode, 4000L, 12, "Estonia");
 		assertEquals(2000, decision.getLoanAmount());
 		assertEquals(20, decision.getLoanPeriod());
 	}
 
 	@Test
-	void testSegment2PersonalCode() throws InvalidLoanPeriodException, NoValidLoanException,
-			InvalidPersonalCodeException, InvalidLoanAmountException {
-		Decision decision = decisionEngine.calculateApprovedLoan(segment2PersonalCode, 4000L, 12);
+	void testSegment2PersonalCode()
+			throws InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
+			InvalidLoanAmountException, InvalidCountryException, InvalidCustomerAgeException {
+		Decision decision = decisionEngine.calculateApprovedLoan(segment2PersonalCode, 4000L, 12, "Estonia");
 		assertEquals(3600, decision.getLoanAmount());
 		assertEquals(12, decision.getLoanPeriod());
 	}
 
 	@Test
-	void testSegment3PersonalCode() throws InvalidLoanPeriodException, NoValidLoanException,
-			InvalidPersonalCodeException, InvalidLoanAmountException {
-		Decision decision = decisionEngine.calculateApprovedLoan(segment3PersonalCode, 4000L, 12);
+	void testSegment3PersonalCode()
+			throws InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
+			InvalidLoanAmountException, InvalidCountryException, InvalidCustomerAgeException {
+		Decision decision = decisionEngine.calculateApprovedLoan(segment3PersonalCode, 4000L, 12, "Estonia");
 		assertEquals(10000, decision.getLoanAmount());
 		assertEquals(12, decision.getLoanPeriod());
 	}
@@ -67,7 +76,7 @@ class DecisionEngineTest {
 	void testInvalidPersonalCode() {
 		String invalidPersonalCode = "12345678901";
 		assertThrows(InvalidPersonalCodeException.class,
-				() -> decisionEngine.calculateApprovedLoan(invalidPersonalCode, 4000L, 12));
+				() -> decisionEngine.calculateApprovedLoan(invalidPersonalCode, 4000L, 12, "Estonia"));
 	}
 
 	@Test
@@ -76,10 +85,10 @@ class DecisionEngineTest {
 		Long tooHighLoanAmount = DecisionEngineConstants.MAXIMUM_LOAN_AMOUNT + 1L;
 
 		assertThrows(InvalidLoanAmountException.class,
-				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, tooLowLoanAmount, 12));
+				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, tooLowLoanAmount, 12, "Estonia"));
 
 		assertThrows(InvalidLoanAmountException.class,
-				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, tooHighLoanAmount, 12));
+				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, tooHighLoanAmount, 12, "Estonia"));
 	}
 
 	@Test
@@ -88,16 +97,17 @@ class DecisionEngineTest {
 		int tooLongLoanPeriod = DecisionEngineConstants.MAXIMUM_LOAN_PERIOD + 1;
 
 		assertThrows(InvalidLoanPeriodException.class,
-				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, 4000L, tooShortLoanPeriod));
+				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, 4000L, tooShortLoanPeriod, "Estonia"));
 
 		assertThrows(InvalidLoanPeriodException.class,
-				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, 4000L, tooLongLoanPeriod));
+				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, 4000L, tooLongLoanPeriod, "Estonia"));
 	}
 
 	@Test
-	void testFindSuitableLoanPeriod() throws InvalidLoanPeriodException, NoValidLoanException,
-			InvalidPersonalCodeException, InvalidLoanAmountException {
-		Decision decision = decisionEngine.calculateApprovedLoan(segment2PersonalCode, 2000L, 12);
+	void testFindSuitableLoanPeriod()
+			throws InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
+			InvalidLoanAmountException, InvalidCountryException, InvalidCustomerAgeException {
+		Decision decision = decisionEngine.calculateApprovedLoan(segment2PersonalCode, 2000L, 12, "Estonia");
 		assertEquals(3600, decision.getLoanAmount());
 		assertEquals(12, decision.getLoanPeriod());
 	}
@@ -105,7 +115,21 @@ class DecisionEngineTest {
 	@Test
 	void testNoValidLoanFound() {
 		assertThrows(NoValidLoanException.class,
-				() -> decisionEngine.calculateApprovedLoan(debtorPersonalCode, 10000L, 60));
+				() -> decisionEngine.calculateApprovedLoan(debtorPersonalCode, 10000L, 60, "Estonia"));
+	}
+
+	@Test
+	void testInvalidCountryException() {
+		assertThrows(InvalidCountryException.class,
+				() -> decisionEngine.calculateApprovedLoan(segment1PersonalCode, 5000L, 60, "Filnald"));
+	}
+
+	@Test
+	void testInvalidAgeException() throws InvalidCustomerAgeException {
+		assertThrows(InvalidCustomerAgeException.class,
+				() -> decisionEngine.calculateApprovedLoan(ageUnderLifetime, 5000L, 60, "Estonia"));
+		assertThrows(InvalidCustomerAgeException.class,
+				() -> decisionEngine.calculateApprovedLoan(ageOverLifetime, 5000L, 60, "Estonia"));
 	}
 
 }


### PR DESCRIPTION
This implementation enables the validation of customer country. A country name must now be provided. If the country is outside the Baltic scope, the loan will not be issued.

Additionally, age validation has been added. The loan will not be issued if the customer is underage or older than the expected lifetime of each respective country minus our maximum loan period.

New class have been created to support these validations.